### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 MCP Server for Datadog API, enabling log search, trace span search, and trace span aggregation functionalities.
 
+<a href="https://glama.ai/mcp/servers/@Nozomuts/datadog-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Nozomuts/datadog-mcp/badge" alt="Datadog Server MCP server" />
+</a>
+
 ### Features
 
 - **Log Search**: Search and retrieve logs from Datadog with flexible query options


### PR DESCRIPTION
This PR adds a badge for the [Datadog MCP Server](https://glama.ai/mcp/servers/@Nozomuts/datadog-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Nozomuts/datadog-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Nozomuts/datadog-mcp/badge" alt="Datadog Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.